### PR TITLE
Added Cloudformation Template for Pentest Exercise

### DIFF
--- a/exercises/ENPM809J-Pentest-Exercises-Cloudformation-Template.yml
+++ b/exercises/ENPM809J-Pentest-Exercises-Cloudformation-Template.yml
@@ -35,20 +35,12 @@ Resources:
       PortRange:
         From: 22
         To: 22
-      RuleNumber: 100
-      Protocol: -1
-      RuleAction: allow
-      Egress: false
-      CidrBlock: 0.0.0.0/0
-      PortRange:
-        From: 0
-        To: 65535
 # Allow all outbound traffic
   OutboundPublicNACLEntry:
     Type: 'AWS::EC2::NetworkAclEntry'
     Properties:
       NetworkAclId: !Ref PublicNACL
-      RuleNumber: 100
+      RuleNumber: 101
       Protocol: -1
       RuleAction: allow
       Egress: true
@@ -62,6 +54,47 @@ Resources:
     Properties: 
       NetworkAclId: !Ref PublicNACL
       SubnetId: !Ref PentestSubnet
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    
+  GatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      InternetGatewayId:
+        Ref: InternetGateway
+      VpcId: !Ref PentestVpc
+    
+  PublicRouteTable:
+    DependsOn:
+      - PentestVpc
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref PentestVpc
+      
+  PublicRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+      RouteTableId: !Ref PublicRouteTable
+      
+  PublicRouteSubnetAssociation:      
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties: 
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PentestSubnet
+
+## Create Security Group that allows SSH inbound
+  SecurityGroupSSH:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      VpcId: !Ref PentestVpc
+      GroupDescription: Base Security Group
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          CidrIp: 0.0.0.0/0
+          FromPort: 22
+          ToPort: 22
 # Create role from existing AWS managed policy
   AdminRole:
     Type: 'AWS::IAM::Role'
@@ -85,7 +118,7 @@ Resources:
     Properties:
       Path: '/'
       Roles:
-      - !Ref AdminRole
+        - !Ref AdminRole
 # create EC2 on subnet and use instance profile
   EC2PentestInstance:
     Type: AWS::EC2::Instance
@@ -96,6 +129,8 @@ Resources:
       IamInstanceProfile:
         !Ref AdminInstanceProfile
       SubnetId: !Ref PentestSubnet
+      SecurityGroupIds: 
+        - !GetAtt SGSSH.GroupId
 # create the user
   DevOpsUser:
     Type: 'AWS::IAM::User'

--- a/exercises/ENPM809J-Pentest-Exercises-Cloudformation-Template.yml
+++ b/exercises/ENPM809J-Pentest-Exercises-Cloudformation-Template.yml
@@ -1,0 +1,139 @@
+Description: A CloudFormation template created for ENPM809J pentest exercises
+Parameters:
+  awsAdministratorAccessPolicy:
+    Type: String
+    Default: 'arn:aws:iam::aws:policy/AdministratorAccess'
+    Description: AWS AdministratorAccess Policy
+Resources:
+  PentestVpc:
+    Type: 'AWS::EC2::VPC'
+    Properties:
+      CidrBlock: 10.0.0.0/24
+      EnableDnsHostnames: true
+      EnableDnsSupport: true
+  PentestSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: us-east-1a
+      CidrBlock: 10.0.0.0/27
+      MapPublicIpOnLaunch: true
+      VpcId: !Ref PentestVpc
+  PublicNACL:
+    Type: 'AWS::EC2::NetworkAcl'
+    Properties:
+      VpcId: !Ref PentestVpc
+# Allow inbound SSH connections from anywhere, and block all else.
+  InboundPublicNACLEntry:
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref PublicNACL
+      RuleNumber: 101
+      Protocol: 6
+      RuleAction: allow
+      Egress: false
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 22
+        To: 22
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: allow
+      Egress: false
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 0
+        To: 65535
+# Allow all outbound traffic
+  OutboundPublicNACLEntry:
+    Type: 'AWS::EC2::NetworkAclEntry'
+    Properties:
+      NetworkAclId: !Ref PublicNACL
+      RuleNumber: 100
+      Protocol: -1
+      RuleAction: allow
+      Egress: true
+      CidrBlock: 0.0.0.0/0
+      PortRange:
+        From: 0
+        To: 65535
+# Attach NACL to subnet
+  PentestSubnetNACLAssociation:
+    Type: AWS::EC2::SubnetNetworkAclAssociation
+    Properties: 
+      NetworkAclId: !Ref PublicNACL
+      SubnetId: !Ref PentestSubnet
+# Create role from existing AWS managed policy
+  AdminRole:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      RoleName: AdminRole
+      AssumeRolePolicyDocument: 
+        Version: '2012-10-17'
+        Statement: 
+          - Effect: Allow
+            Principal: 
+              Service: 
+                - ec2.amazonaws.com
+            Action: 
+              - sts:AssumeRole
+      Path: /
+      ManagedPolicyArns:
+        - !Ref awsAdministratorAccessPolicy #Use the AWS managed policy from Parameters section
+# create instance profile from role
+  AdminInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Path: '/'
+      Roles:
+      - !Ref AdminRole
+# create EC2 on subnet and use instance profile
+  EC2PentestInstance:
+    Type: AWS::EC2::Instance
+    Version: '2009-05-15'
+    Properties:
+      ImageId: ami-0b898040803850657 # Amazon Linux 2 AMI (HVM), SSD Volume Type 
+      InstanceType: t2.micro
+      IamInstanceProfile:
+        !Ref AdminInstanceProfile
+      SubnetId: !Ref PentestSubnet
+# create the user
+  DevOpsUser:
+    Type: 'AWS::IAM::User'
+    Properties:
+      Path: /
+      LoginProfile:
+        Password: myP@ssW0rd
+      Policies:
+      - PolicyName: DevOpsUserPolicy
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement: 
+          - Effect: Allow
+            Action:
+            - iam:CreateInstanceProfile
+            - iam:PassRole
+            - iam:ListInstanceProfiles
+            - iam:AddRoleToInstanceProfile
+            - ec2:AssociateIamInstanceProfile
+            Resource:
+            - arn:aws:iam::*:instance-profile/*
+            - arn:aws:iam::*:role/*
+            - arn:aws:ec2:*:*:instance/*
+          - Effect: Allow
+            Action:
+            - ec2:DescribeInstances
+            - ec2:RunInstances
+            - ec2:CreateKeyPair
+            Resource: '*'
+# create key for AWS CLI access
+  DevOpsAccessKey:
+    Type: AWS::IAM::AccessKey
+    Properties:
+      UserName:
+        !Ref DevOpsUser
+# Send key information to the "outputs" tab of the cloudformation "stack details" page.
+Outputs: 
+  DevOpsAccessKeyID: 
+    Value: !Ref DevOpsAccessKey
+  DevOpsSecretAccessKey:
+    Value: !GetAtt DevOpsAccessKey.SecretAccessKey

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,0 +1,3 @@
+# ENPM809J Exercise CloudFormation Templates
+
+Upload via the "create stack" button in the AWS CloudFormation service page.

--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,3 +1,4 @@
 # ENPM809J Exercise CloudFormation Templates
 
-Upload via the "create stack" button in the AWS CloudFormation service page.
+ This template creates a VPC, subnet, IAM policies, and other resources to accomplish the in class lab. 
+ Upload the .yml file via the "create stack" button in the AWS CloudFormation service page.


### PR DESCRIPTION
I (and others) had trouble with this exercise due to the changes I made to my AWS account while working on the final. This primarily was due to deleting my default VPC, but also a couple other minor items. This template creates a VPC, subnet, and all other juicy bits automatically. There are a couple updates needed for the exercise document, which I've attached. 
[ENPM809J-Pentest-Exercise-Document-Updates.txt](https://github.com/kts262/enpm809j/files/3539137/ENPM809J-Pentest-Exercise-Document-Updates.txt)

I hope you get the chance to try this out and maybe use it for a class!